### PR TITLE
Updating code to run cross platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ To use it, do these things:
 * You will first need to download Gutenberg's RDF catalog and import it into the local database. Do this:
    * `pgtk getcat`
 * Then:
-   * `pgtk mkdir`
+   * `pgtk mkdb`
    
 To find and download content, follow this pattern:
 * Search for something

--- a/pgtk
+++ b/pgtk
@@ -5,9 +5,11 @@
 # Core
 import glob
 import os
+import shutil
 import sys
-import subprocess
 import re
+import tarfile
+import zipfile
 
 # Data
 import pandas as pd
@@ -26,9 +28,13 @@ try:
 except KeyError:
     sys.exit('Please set PGTK_HOME.')
 
-rdf_dir = pgtk_home + '/cache/epub'
-rdf_path = rdf_dir + '/{0}/pg{0}.rdf'
-db_name = pgtk_home + '/gutenberg.db'
+if not os.path.exists(pgtk_home):
+    print('Creating new pgtk home at {0}'.format(pgtk_home))
+    os.mkdir(pgtk_home)
+
+rdf_dir = os.path.join(pgtk_home, 'cache', 'epub')
+rdf_path = os.path.join(rdf_dir, '{0}', 'pg{0}.rdf')
+db_name = os.path.join(pgtk_home, 'gutenberg.db')
 pg_rdf_url = "https://www.gutenberg.org/cache/epub/feeds/rdf-files.tar.zip"
 pg_index_url = "https://www.gutenberg.org/dirs/GUTINDEX.zip"
 gut_url = 'https://www.gutenberg.org/ebooks/{}'
@@ -77,10 +83,8 @@ default_formats_rgx =  re.compile(default_formats_str)
 #%% Core Functions
 
 def get_gids():
-    gids = [path.split('/')[-1]
-        for path in glob.glob(rdf_dir + '/*')]
-    gids = [int(gid) for gid in gids
-        if not re.search(r'[^0-9]+', gid)]
+    gids = [os.path.basename(path) for path in glob.glob(os.path.join(rdf_dir, '*'))]
+    gids = [int(gid) for gid in gids if not re.search(r'[^0-9]+', gid)]
     gids = sorted(gids)
     return gids
 
@@ -134,8 +138,9 @@ def get_catalog_wide(df):
         .unstack().fillna('NONE GIVEN')
     return df_wide
 
-def get_reduced_wide(df, cols=['title', 'creators', 'formats', 'languages', 'types']):
-    return df[cols]
+def get_reduced_wide(df, cols=None):
+    mycols = cols if cols is not None else ['title', 'creators', 'formats', 'languages', 'types']
+    return df[mycols]
 
 def get_catalog_text(df_wide):
     df_wide = df_wide.loc[df_wide.languages == 'en']
@@ -162,6 +167,40 @@ def get_gids_for_pat_from_db(catalog, name_pat, key='creators'):
         df = pd.read_sql(sql, db, params=(name_pat,))
         return df.gid.tolist()
 
+#%% Cross platform utilities
+
+def wget(url, workingdir=None):
+    stream = requests.get(url, stream=True)
+
+    total_size = int(stream.headers.get('content-length', 0))
+    progress_bar = tqdm(total=total_size, unit='iB', unit_scale=True, desc='Downloading   ')
+
+    with open(os.path.join(workingdir, url.split('/')[-1]), 'wb') as f:
+        for chunk in stream.iter_content(chunk_size=1024):
+            progress_bar.update(len(chunk))
+            f.write(chunk)
+    progress_bar.close()
+
+
+def unzip(zip, workingdir=None):
+    with zipfile.ZipFile(os.path.join(workingdir, zip)) as z:
+        for element in tqdm(z.infolist(), desc='Decompressing '):
+            z.extract(element, workingdir)
+
+def tar_xf(mytarfile, workingdir=None):
+    with tarfile.open(os.path.join(workingdir, mytarfile)) as t:
+        for element in tqdm(t.getmembers(), desc='Extracting    '):
+            t.extract(element, workingdir)
+
+def rm(file, workingdir=None, recursive=False):
+    effective_file = os.path.join(workingdir, file) if workingdir else file
+    if os.path.exists(effective_file):
+        if recursive:
+            shutil.rmtree(effective_file)
+        else:
+            os.remove(effective_file)
+
+
 #%% User Commands
 
 def download_cache(overwrite=True):
@@ -170,11 +209,11 @@ def download_cache(overwrite=True):
         print("Downloading RDF cache")
         rdf_zip = pg_rdf_url.split('/')[-1]
         rdf_tar =  rdf_zip.replace('.zip', '')
-        subprocess.run(['wget', pg_rdf_url], cwd=pgtk_home)
-        subprocess.run(['unzip', rdf_zip], cwd=pgtk_home)
-        subprocess.run(['tar', '-xf', rdf_tar], cwd=pgtk_home)
-        subprocess.run(['rm', rdf_zip], cwd=pgtk_home)
-        subprocess.run(['rm', rdf_tar], cwd=pgtk_home)
+        wget(pg_rdf_url, workingdir=pgtk_home)
+        unzip(rdf_zip, workingdir=pgtk_home)
+        tar_xf(rdf_tar, workingdir=pgtk_home)
+        rm(rdf_zip, workingdir=pgtk_home)
+        rm(rdf_tar, workingdir=pgtk_home)
     else:
         print("RDF files exist on system. Set '--overwrite True'.")
 
@@ -183,7 +222,7 @@ def populate_database(replace=False):
     print("Creating database from RDF cache")
     if replace or not os.path.exists(db_name):
         if  os.path.exists(rdf_dir):
-            print('Exracting data from cataglog')
+            print('Extracting data from catalog')
             gids = get_gids()
             cat = get_catalog(gids)
             print("Converting data into wide form")
@@ -198,7 +237,7 @@ def populate_database(replace=False):
 def remove_cache():
     """Remove RDF cache from file system"""
     print("Removing RDF cache in", rdf_dir)
-    subprocess.run(['rm', '-rfv', rdf_dir])
+    rm(rdf_dir, recursive=True)
 
 def print_results(results):
     """Print search results in standard format"""
@@ -211,7 +250,7 @@ def print_results(results):
             gut_utf8.format(item.gid))
         data.append(row)
     _ = [print('|'.join(row)) for row in data]
-    print('#', len(data), "items returned")
+    #print('#', len(data), "items returned")
     return data
         
 def run_query(where_clause, limit=1000):
@@ -228,19 +267,20 @@ def search_fields(ti='', cr='', su='', la='EN', ty='TEXT', fo='%TEXT/PLAIN%'):
     Also: languages (la) defaults to 'EN', types (ty) defaults to 'TEXT', and 
     formats (fo) defaults to '%TEXT/PLAIN%'.
     """
-    args = dict(ti=ti, cr=cr, su=su, la=la, ty=ty, fo=fo) #locals()                                                               
+    args = dict(ti=ti, cr=cr, su=su, la=la, fo=fo) #locals()
     where_clause_list = []
     params = []
     for f in args:
         if args[f] != '':
             where_clause_list.append("{} LIKE ? ".format(cat_fields[f]))            
-            if type(args[f]).__name__ == 'tuple':
+            if isinstance(args[f], tuple):
                 args[f] = ', '.join(args[f])
             if f == 'ti' or f == 'su' or f == 'cr':
                 args[f] = "%{}%".format(args[f].upper())
             params.append(args[f])
     where_clause = ' AND '.join(where_clause_list)
-    sql = "SELECT * FROM catalog WHERE {} ORDER BY creators, title".format(where_clause)
+    types_returned = '{} in ("{}", "NONE GIVEN")'.format(cat_fields['ty'], ty)
+    sql = "SELECT * FROM catalog WHERE {} AND {} ORDER BY creators, title".format(where_clause, types_returned)
     with sqlite3.connect(db_name) as db:
         results = pd.read_sql_query(sql, db, params=params)
         print_results(results)
@@ -254,20 +294,24 @@ def download_epubs(epub_file, outdir=None, sep='|'):
         os.mkdir(outdir)        
     
     print("Downloading files to", outdir)
-    with open(epub_file, 'r') as file:
-        for line in file.readlines():
+    with open(epub_file, 'r') as fyle:
+        for line in fyle.readlines():
             row = line.split(sep)
             gid = row[0]
             try:
-                int(gid)         
                 url = gut_utf8.format(gid)
-                r = requests.get(url)
+                stream = requests.get(url, stream=True)
+                total_size = int(stream.headers.get('content-length', 0))
+                progress_bar = tqdm(total=total_size, unit='iB', unit_scale=True, desc='Downloading {}'.format(gid))
                 filename = '_'.join(row[1:3]).strip()
                 filename = re.sub(r'\W+', '_', filename)
                 filename = re.sub(r'_+', '_', filename)
-                print(gid, filename)       
-                with open("{}/{}-pg{}.txt".format(outdir, filename, gid), 'w') as outfile:
-                    outfile.write(r.text)
+
+                with open(os.path.join(outdir, '{}-pg{}.txt'.format(filename, gid)), 'wb') as f:
+                    for chunk in stream.iter_content(chunk_size=1024):
+                        progress_bar.update(len(chunk))
+                        f.write(chunk)
+                progress_bar.close()
             except ValueError as e:
                 print('#', gid, "not a GID")
 


### PR DESCRIPTION
I updated various parts of the code to be cross platform and not depend upon unix coreutils and subprocess calls.  I've mostly left the code intact where I could, and replaced each subprocess call with a function that performed similar operations to their command line counterparts.

One bizarre behavior I've experienced with the current baseline is that type types being returned in the Gutenberg catalog has 'NONE GIVEN' for the lionshare of the dataset.  As such, I've added this as a default behavior on line 282 to always include the NONE GIVEN type.  I'm not sure if this is the best way forward for the code, but it does fix the demo query provided when looking up Austen's novels as described in the README.md.